### PR TITLE
move api_server gitignore back into it's proper place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,6 @@
-### Intellij ###
-.idea/
-out/
-build/
-out/
-*.iml
-
-### Gradle ###
-.gradle
-/build/
-
-# Ignore Gradle GUI config
-gradle-app.setting
-
-# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
-!gradle-wrapper.jar
-
-# Cache of project
-.gradletasknamecache
-
 ### AWS ###
 *.pem
 
 ### OSX ###
 .DS_Store
+

--- a/api_server/.gitignore
+++ b/api_server/.gitignore
@@ -1,0 +1,19 @@
+### Intellij ###
+.idea/
+out/
+build/
+out/
+*.iml
+
+### Gradle ###
+.gradle
+/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Cache of project
+.gradletasknamecache


### PR DESCRIPTION
Move api_server related things into the api_server gitignore, kept the `.pem` and `.DS_Store` in the global gitignore just to make sure we don't accidentally add those anywhere in our project.